### PR TITLE
fix "no attribute 'RMSPropOptimizer'" error basic_regression.ipynb

### DIFF
--- a/samples/core/tutorials/keras/basic_regression.ipynb
+++ b/samples/core/tutorials/keras/basic_regression.ipynb
@@ -369,7 +369,7 @@
         "    keras.layers.Dense(1)\n",
         "  ])\n",
         "\n",
-        "  optimizer = tf.train.RMSPropOptimizer(0.001)\n",
+        "  optimizer = tf.keras.optimizers.RMSprop()\n",
         "\n",
         "  model.compile(loss='mse',\n",
         "                optimizer=optimizer,\n",


### PR DESCRIPTION
# Description


> :memo: fix "no attribute 'RMSPropOptimizer'" error basic_regression.ipynb
>  
> * While searching for a simple demo of basic-regression I came across this, but got  AttributeError: module 'tensorflow._api.v2.train' has no attribute 'RMSPropOptimizer'
> * using tf.__version__ == "2.4.1"

Needed to made the following change to basic_regression.ipynb 

optimizer = tf.train.RMSPropOptimizer(0.001)
   to
optimizer = tf.keras.optimizers.RMSprop()

to avoid getting
  AttributeError: module 'tensorflow._api.v2.train' has no attribute 'RMSPropOptimizer'

with tf.__version__ == "2.4.1"




## Type of change

- [x] TensorFlow 2 migration

## Tests

> :memo: Verified that the error occured on out of the box colab, and it compiles and runs with the change
>  
> * reproduce using tf 2.4.1  

**Test Configuration**:

## Checklist

- [x] I have signed the [Contributor License Agreement](https://github.com/tensorflow/models/wiki/Contributor-License-Agreements).
- [x] I have read [guidelines for pull request](https://github.com/tensorflow/models/wiki/Submitting-a-pull-request).
- [x] My code follows the [coding guidelines](https://github.com/tensorflow/models/wiki/Coding-guidelines).
- [x] I have performed a self [code review](https://github.com/tensorflow/models/wiki/Code-review) of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
